### PR TITLE
Create 1.0.0-alpha01 release for data protection packages

### DIFF
--- a/Google.Cloud.AspNetCore/Google.Cloud.AspNetCore.DataProtection.Kms/Google.Cloud.AspNetCore.DataProtection.Kms.csproj
+++ b/Google.Cloud.AspNetCore/Google.Cloud.AspNetCore.DataProtection.Kms/Google.Cloud.AspNetCore.DataProtection.Kms.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.0.0-alpha00</Version>
+    <Version>1.0.0-alpha01</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -13,7 +13,7 @@
     <Copyright>Copyright 2019 Google LLC</Copyright>
     <Authors>Google Inc.</Authors>
     <PackageIconUrl>https://cloud.google.com/images/gcp-icon-64x64.png</PackageIconUrl>
-    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack</RepositoryUrl>

--- a/Google.Cloud.AspNetCore/Google.Cloud.AspNetCore.DataProtection.Storage/Google.Cloud.AspNetCore.DataProtection.Storage.csproj
+++ b/Google.Cloud.AspNetCore/Google.Cloud.AspNetCore.DataProtection.Storage/Google.Cloud.AspNetCore.DataProtection.Storage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.0.0-alpha00</Version>
+    <Version>1.0.0-alpha01</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -13,7 +13,7 @@
     <Copyright>Copyright 2019 Google LLC</Copyright>
     <Authors>Google Inc.</Authors>
     <PackageIconUrl>https://cloud.google.com/images/gcp-icon-64x64.png</PackageIconUrl>
-    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack</RepositoryUrl>


### PR DESCRIPTION
This also uses PackageLicenseExpression to replace PackageLicenseUrl.
See https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg