### PR TITLE
Allow StorageClient (or GoogleCredential) to be picked up from dependency injection

### DIFF
--- a/Google.Cloud.AspNetCore/Google.Cloud.AspNetCore.DataProtection.Storage/CloudStorageXmlRepository.cs
+++ b/Google.Cloud.AspNetCore/Google.Cloud.AspNetCore.DataProtection.Storage/CloudStorageXmlRepository.cs
@@ -30,7 +30,7 @@ namespace Google.Cloud.AspNetCore.DataProtection.Storage
 {
     /// <summary>
     /// Implementation of <see cref="IXmlRepository"/> that stores the protected elements in a single Google Cloud Storage file.
-    /// This class is configured by <see cref="GoogleCloudDataProtectionBuilderExtensions.PersistKeysToGoogleCloudStorage(IDataProtectionBuilder, StorageClient, string, string)" />
+    /// This class is configured by <see cref="GoogleCloudDataProtectionBuilderExtensions.PersistKeysToGoogleCloudStorage(IDataProtectionBuilder, string, string, StorageClient)" />
     /// (and other overloads).
     /// </summary>
     internal sealed partial class CloudStorageXmlRepository : IXmlRepository


### PR DESCRIPTION
This means if the user has already called `services.AddSingleton(storageClient)` or `services.AddSingleton(googleCredential)`, but not specified a `StorageClient` when configuring data protection, those existing services will be used.

It's harder to do this with KMS, but I'm working on it. (Initially that may *only* support the client itself being configured elsewhere. We'll see.)

The order of the parameters has now been moved as the `StorageClient` is fully optional. (I could have used an optional parameter instead, in fact. Thoughts welcome on that.)