### PR TITLE
Downgrade Firestore.DistributedCache dependencies to 2.1.

### DIFF
--- a/Google.Cloud.AspNetCore/Google.Cloud.AspNetCore.Firestore.DistributedCache/Google.Cloud.AspNetCore.Firestore.DistributedCache.csproj
+++ b/Google.Cloud.AspNetCore/Google.Cloud.AspNetCore.Firestore.DistributedCache/Google.Cloud.AspNetCore.Firestore.DistributedCache.csproj
@@ -21,9 +21,9 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Firestore" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
     <None Include="../../LICENSE" Pack="true" PackagePath="" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Because 2.1 will be supported longer than 2.2.  And I'm updating
samples to depend on 2.1 instead of 2.2.