### PR TITLE
Release Google.Cloud.AspNetCore.Firestore.DistributedCache 1.0.0-alpha02

### DIFF
--- a/Google.Cloud.AspNetCore/Google.Cloud.AspNetCore.Firestore.DistributedCache/Google.Cloud.AspNetCore.Firestore.DistributedCache.csproj
+++ b/Google.Cloud.AspNetCore/Google.Cloud.AspNetCore.Firestore.DistributedCache/Google.Cloud.AspNetCore.Firestore.DistributedCache.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.0.0-alpha01</Version>
+    <Version>1.0.0-alpha02</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyOriginatorKeyFile>../../GoogleApis.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
The only change is to the dependencies, now from ASP.NET Core 2.1.