### PR TITLE
Delete .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: csharp
-mono: none
-dotnet: 2.2.104
-dist: xenial
-
-script:
-  - dotnet build Google.Cloud.AspNetCore
-  - dotnet test Google.Cloud.AspNetCore/Google.Cloud.AspNetCore.Tests


### PR DESCRIPTION
We don't use Travis any more (and it was never enabled for this repo)